### PR TITLE
fix: correct bug where remove did not reload correctly

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -85,10 +85,7 @@ class Tasklist {
             let date = parseInt(event.target.offsetParent.dataset.id)
             const task = tasks.find(task => task.date === date);
             task.status = task.status === "completed" ? "pending" : "completed";
-            localStorage.setItem('tasks', JSON.stringify([
-                ...tasks.filter(task => task.date !== date),
-                task
-            ]));
+            localStorage.setItem('tasks', JSON.stringify(tasks));
         }
     }
 

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -83,8 +83,12 @@ class Tasklist {
     static complete(event) {
         if(event.target.parentElement.classList.contains('form-check')){
             let date = parseInt(event.target.offsetParent.dataset.id)
-            tasks.find(task => task.date === date).status = 'completed';
-            localStorage.setItem('tasks', JSON.stringify(tasks));
+            const task = tasks.find(task => task.date === date);
+            task.status = task.status === "completed" ? "pending" : "completed";
+            localStorage.setItem('tasks', JSON.stringify([
+                ...tasks.filter(task => task.date !== date),
+                task
+            ]));
         }
     }
 


### PR DESCRIPTION
This fix the bug that if you reloaded the page the checkbox were still checked as completed.
The problem was the tasks were not serialized correctly after completion.

Closes #15